### PR TITLE
Fixed ShadowCaster2DTileMap

### DIFF
--- a/Assets/ShadowCaster2DTileMap.cs
+++ b/Assets/ShadowCaster2DTileMap.cs
@@ -1,7 +1,7 @@
 using System.Linq;
 using System.Reflection;
 using UnityEngine;
-using UnityEngine.Experimental.Rendering.Universal;
+using UnityEngine.Rendering.Universal;
 
 [RequireComponent(typeof(CompositeCollider2D))]
 public class ShadowCaster2DTileMap : MonoBehaviour
@@ -16,9 +16,10 @@ public class ShadowCaster2DTileMap : MonoBehaviour
 
     static readonly FieldInfo meshField = typeof(ShadowCaster2D).GetField("m_Mesh", BindingFlags.NonPublic | BindingFlags.Instance);
     static readonly FieldInfo shapePathField = typeof(ShadowCaster2D).GetField("m_ShapePath", BindingFlags.NonPublic | BindingFlags.Instance);
+    static readonly FieldInfo shapePathHashField = typeof(ShadowCaster2D).GetField("m_ShapePathHash", BindingFlags.NonPublic | BindingFlags.Instance);
     static readonly MethodInfo generateShadowMeshMethod = typeof(ShadowCaster2D)
                                     .Assembly
-                                    .GetType("UnityEngine.Experimental.Rendering.Universal.ShadowUtility")
+                                    .GetType("UnityEngine.Rendering.Universal.ShadowUtility")
                                     .GetMethod("GenerateShadowMesh", BindingFlags.Public | BindingFlags.Static);
     public void Generate()
     {
@@ -42,6 +43,7 @@ public class ShadowCaster2DTileMap : MonoBehaviour
             }
 
             shapePathField.SetValue(shadowCasterComponent, testPath);
+            shapePathHashField.SetValue(shadowCasterComponent, Random.Range(int.MinValue, int.MaxValue));
             meshField.SetValue(shadowCasterComponent, new Mesh());
             generateShadowMeshMethod.Invoke(shadowCasterComponent, new object[] { meshField.GetValue(shadowCasterComponent), shapePathField.GetValue(shadowCasterComponent) });
         }


### PR DESCRIPTION
On newer unity versions they removed the ".Experimental" from the namespace and now generated Shadow Casters 2D doesn't works as it needs to have a value different from 0 on the field "m_ShapePathHash", both issues were fixed on this commit with pretty simple changes and will work right out of the batch.